### PR TITLE
Added IE11 support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 import mixin from './mixin'
+import utils from './utils'
 
 export default function(Vue) {
   Vue.mixin(mixin)
 }
 
 export function timer(name, time, options) {
-  return mixin.assign({ name: name, time: time }, options)
+  return utils.assign({ name: name, time: time }, options)
 }

--- a/index.js
+++ b/index.js
@@ -5,5 +5,5 @@ export default function(Vue) {
 }
 
 export function timer(name, time, options) {
-  return Object.assign({ name: name, time: time }, options)
+  return mixin.assign({ name: name, time: time }, options)
 }

--- a/mixin.js
+++ b/mixin.js
@@ -1,4 +1,4 @@
-import { has, set, isFunction } from './utils'
+import { set } from './utils'
 
 function generateData(timers) {
   return Object.keys(timers).reduce(function(acc, cur) {
@@ -60,15 +60,15 @@ function normalizeConfig(config, vm) {
 function normalizeOptions(options, vm) {
   return Array.isArray(options)
     ? options.reduce(function(res, config) {
-        return set(config.name, normalizeConfig(config, vm), res)
-      }, {})
+      return set(config.name, normalizeConfig(config, vm), res)
+    }, {})
     : Object.keys(options).reduce(function(res, key) {
-        return set(
-          key,
-          normalizeConfig(set('name', key, options[key]), vm),
-          res
-        )
-      }, {})
+      return set(
+        key,
+        normalizeConfig(set('name', key, options[key]), vm),
+        res
+      )
+    }, {})
 }
 
 export default {

--- a/mixin.js
+++ b/mixin.js
@@ -60,15 +60,15 @@ function normalizeConfig(config, vm) {
 function normalizeOptions(options, vm) {
   return Array.isArray(options)
     ? options.reduce(function(res, config) {
-      return set(config.name, normalizeConfig(config, vm), res)
-    }, {})
+        return set(config.name, normalizeConfig(config, vm), res)
+      }, {})
     : Object.keys(options).reduce(function(res, key) {
-      return set(
-        key,
-        normalizeConfig(set('name', key, options[key]), vm),
-        res
-      )
-    }, {})
+        return set(
+          key,
+          normalizeConfig(set('name', key, options[key]), vm),
+          res
+        )
+      }, {})
 }
 
 export default {
@@ -112,6 +112,7 @@ export default {
         }
         if (!data[name].isRunning) return
         clearTimer(options[name].repeat)(data[name].instance)
+        data[name].isRunning = false
         vm.$emit('timer-stop:' + name)
       }
     }

--- a/mixin.js
+++ b/mixin.js
@@ -1,4 +1,6 @@
-import { set } from './utils'
+import { utils } from './utils'
+
+var set = utils.set
 
 function generateData(timers) {
   return Object.keys(timers).reduce(function(acc, cur) {
@@ -135,21 +137,5 @@ export default {
     Object.keys(vm.$options.timers).forEach(function(key) {
       vm.$timer.stop(key)
     })
-  },
-
-  /**
-   * Polyfill for Object.assign for IE11 support
-   */
-  assign: function (to){
-    var assign = Object.assign || function assign(to) {
-      for (var s = 1; s < arguments.length; s += 1) {
-        var from = arguments[s]
-        for (var key in from) {
-          to[key] = from[key]
-        }
-      }
-      return to
-    }
-    return assign
   }
 }

--- a/mixin.js
+++ b/mixin.js
@@ -135,5 +135,21 @@ export default {
     Object.keys(vm.$options.timers).forEach(function(key) {
       vm.$timer.stop(key)
     })
+  },
+
+  /**
+   * Polyfill for Object.assign for IE11 support
+   */
+  assign: function (to){
+    var assign = Object.assign || function assign(to) {
+      for (var s = 1; s < arguments.length; s += 1) {
+        var from = arguments[s]
+        for (var key in from) {
+          to[key] = from[key]
+        }
+      }
+      return to
+    }
+    return assign
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-timers",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "description": "Mixin to manage your intervals in Vue.js",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-timers",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "license": "MIT",
   "description": "Mixin to manage your intervals in Vue.js",
   "main": "index.js",

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,24 @@
 import mixin from './mixin'
 
-export function set(key, value, obj) {
-  const clone = mixin.assign({}, obj)
-  clone[key] = value
-  return clone
+const util = {
+  set: function (key, value, obj) {
+    const clone = this.assign({}, obj)
+    clone[key] = value
+    return clone
+  },
+  
+  /**
+   * Polyfill for Object.assign for IE11 support
+   */
+  assign: Object.assign || function assign(to) {
+    for (var s = 1; s < arguments.length; s += 1) {
+      var from = arguments[s]
+      for (var key in from) {
+        to[key] = from[key]
+      }
+    }
+    return to
+  }
 }
+
+export default util

--- a/utils.js
+++ b/utils.js
@@ -1,13 +1,3 @@
-export function isFunction(cb) {
-  return typeof callback === 'function'
-}
-
-export function has(prop) {
-  return function(obj) {
-    return prop in obj
-  }
-}
-
 export function set(key, value, obj) {
   const clone = Object.assign({}, obj)
   clone[key] = value

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,7 @@
+import mixin from './mixin'
+
 export function set(key, value, obj) {
-  const clone = Object.assign({}, obj)
+  const clone = mixin.assign({}, obj)
   clone[key] = value
   return clone
 }


### PR DESCRIPTION
[Object.assign] isn't supported by IE11.  Replaced in two files [index.js] & [utils.js].

See reference:
https://stackoverflow.com/questions/42091600/how-to-merge-object-in-ie-11?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa