### PR TITLE
Fix various bugs

### DIFF
--- a/mixin.js
+++ b/mixin.js
@@ -60,15 +60,15 @@ function normalizeConfig(config, vm) {
 function normalizeOptions(options, vm) {
   return Array.isArray(options)
     ? options.reduce(function(res, config) {
-        return set(config.name, normalizeConfig(config, vm), res)
-      }, {})
+      return set(config.name, normalizeConfig(config, vm), res)
+    }, {})
     : Object.keys(options).reduce(function(res, key) {
-        return set(
-          key,
-          normalizeConfig(set('name', key, options[key]), vm),
-          res
-        )
-      }, {})
+      return set(
+        key,
+        normalizeConfig(set('name', key, options[key]), vm),
+        res
+      )
+    }, {})
 }
 
 export default {

--- a/mixin.js
+++ b/mixin.js
@@ -92,6 +92,7 @@ export default {
             '[vue-timers.start] Cannot find timer ' + name
           )
         }
+        if (data[name].isRunning) return
         data[name].isRunning = true
         data[name].instance = generateTimer(
           set('time', data[name].time, options[name]),

--- a/mixin.js
+++ b/mixin.js
@@ -6,7 +6,7 @@ function generateData(timers) {
       cur,
       {
         isRunning: false,
-        timer: timers[cur].time || 0,
+        time: timers[cur].time || 0,
         instance: null
       },
       acc

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,3 @@
-import mixin from './mixin'
-
 export const set = function(key, value, obj) {
   const clone = assign({}, obj)
   clone[key] = value


### PR DESCRIPTION
Most notably, this fixes the bug where **all timers had a `time` of `0`** (unless set via `this.timers`) from commit f84bd9f7c10ff60092f258cee8fe28590cf091fc. Due to commit 3e71764fb7739168f497ac0ef2fd1438b726eb09 erroneously using the `timer` property instead of `time` for `this.timers`, the object passed into `generateTimer` set an unused property `timer` to an unused property `time` of `this.timers` (which would be undefined) - which would have no effect. Commit f84bd9f7c10ff60092f258cee8fe28590cf091fc instead overrode the existing `time` property instead (correctly) with an undefined property (incorrectly). This is fixed by renaming the property in `this.timers` to `time` as expected.

Additionally, starting a timer twice results in the previous timer being unable to be stopped. This is fixed by avoiding starting timers which are already running.

(I don't use Vue and I've only tested this with a small boilerplate app, so apologies if I've broken something.)