### PR TITLE
Fix 'autostart' default documentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ export default {
   callback: Function/String,
 
   // Autostart timer from created hook
-  // Default: true
+  // Default: false
   autostart: Boolean,
 
   // Set true to repeat (with setInterval) or false (setTimeout)


### PR DESCRIPTION
Default for 'autostart' is 'false' but documentation says 'true'.

Reference: https://github.com/Kelin2025/vue-timers/blob/master/mixin.js#L55