### PR TITLE
Use the 'methods' mixin merge strategy.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import mixin from './mixin'
 import { assign } from './utils'
 
 export default function(Vue) {
+  Vue.config.optionMergeStrategies.timers = Vue.config.optionMergeStrategies.methods
   Vue.mixin(mixin)
 }
 


### PR DESCRIPTION
By default, Vue will use the 'overwrite' strategy for custom options.  For vue-timers, this means components with timers will ignore all timers coming from an added mixin.  We switch to the 'methods' strategy, which merges the two sets of timers, favoring component keys where they match.